### PR TITLE
move away from apidock

### DIFF
--- a/autoload/rubydoc.vim
+++ b/autoload/rubydoc.vim
@@ -12,6 +12,13 @@ function! s:execute(cmd)
 endfunction
 
 function! rubydoc#search(type, keyword)
-  let url = '"http://apidock.com/'.a:type.'/search/quick?query='.a:keyword.'"'
+  if a:type == 'ruby'
+    let url = 'http://rubydoc.info/search/stdlib/core?q='
+  elseif a:type == 'rspec'
+    let url = 'https://www.relishapp.com/rspec/search?query='
+  elseif a:type == 'rails'
+    let url = 'http://api.rubyonrails.org/?q='
+  endif
+  let url = '"'.url.a:keyword.'"'
   call s:execute(g:ruby_doc_command.' '.url)
 endfunction


### PR DESCRIPTION
I kinda dislike the way apidock responds to search queries (i.e. showing old documentation when stuff was moved or deprecated). Also I prefer having the most recent documentation..
- ruby: http://rubydoc.info/search/stdlib/core
- rails: http://api.rubyonrails.org
- rspec: https://www.relishapp.com/rspec
